### PR TITLE
using boolean flag to track persistent orders.

### DIFF
--- a/src/main/scala/org/economicsl/auctions/orders/Order.scala
+++ b/src/main/scala/org/economicsl/auctions/orders/Order.scala
@@ -25,6 +25,8 @@ sealed trait Order {
 
   def issuer: UUID
 
+  def isPersistent: Boolean
+
   def tradable: Tradable
 
 }

--- a/src/main/scala/org/economicsl/auctions/orders/Persistent.scala
+++ b/src/main/scala/org/economicsl/auctions/orders/Persistent.scala
@@ -20,4 +20,6 @@ package org.economicsl.auctions.orders
 trait Persistent {
   this: Order =>
 
+  val isPersistent: Boolean = true
+
 }


### PR DESCRIPTION
...this feature is necessary for double auctions...